### PR TITLE
Fix setDeteceted

### DIFF
--- a/lib/accessory.js
+++ b/lib/accessory.js
@@ -89,25 +89,28 @@ class OccupancySensor {
 		
 	}
 
-	setDetected(isDetected, device) {
-		clearTimeout(this.thresholdTimer)
-		if (isDetected && !this.isDetected) {
-			this.log(`[${this.name}] - connected to the network (mac: ${device.mac} | ip:${device.ip} | hostname:${device.name})`)
-			this.isDetected = 1
-			this.OccupancySensorService
-				.getCharacteristic(Characteristic.OccupancyDetected)
-				.updateValue(1)
-			return
+	setDetected(isDetected, device) {		
+		if (isDetected) {
+			clearTimeout(this.thresholdTimer)
+			this.thresholdTimer = null;
+
+			if (!this.isDetected) {
+				this.log(`[${this.name}] - connected to the network (mac: ${device.mac} | ip:${device.ip} | hostname:${device.name})`)
+				this.isDetected = 1
+				this.OccupancySensorService
+					.getCharacteristic(Characteristic.OccupancyDetected)
+					.updateValue(1)
+			}
+		} else {
+			this.thresholdTimer = setTimeout(() => {
+				this.log(`[${this.name}] - disconnected from the network (mac: ${device.mac} | ip:${device.ip} | hostname:${device.name})`)
+				this.isDetected = 0
+				this.OccupancySensorService
+					.getCharacteristic(Characteristic.OccupancyDetected)
+					.updateValue(0)
+	
+			}, this.threshold * 60 * 1000)	
 		}
-
-		this.thresholdTimer = setTimeout(() => {
-			this.log(`[${this.name}] - disconnected from the network (mac: ${device.mac} | ip:${device.ip} | hostname:${device.name})`)
-			this.isDetected = 0
-			this.OccupancySensorService
-				.getCharacteristic(Characteristic.OccupancyDetected)
-				.updateValue(0)
-
-		}, this.threshold * 60 * 1000)
 	}
 
 


### PR DESCRIPTION
Assuming the following scenario -
1. Device A is in this.isDetected = 1 state
2. A disconnects from the network - setDetected is called with isDetected = 0, creating a timer that will trigger in `threshold` minutes. A is still on this.isDetected = 1.
3. A connects back to the network before the timer fires, the previous timer is canceled *but* a new timer begins (since we do not enter the first if condition in setDetected)
4. the timer fires, setting A's isDetected to 0.
the network.js code now assumes that A is connected, it won't fire any new connected/disconnected event for that device

The solution is to make sure that only isDetected=0 creates a timer and that only isDetecetd=1 cancels the timer